### PR TITLE
Showing 'recovered from error' issue for parse failures

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -14,7 +14,7 @@
             </div>
         </div>
         <div id="error-div" style="display:none; font-size:24px; font-family:monospace; color:red;">
-            An error happened. :(
+            <div id="error-happened-div">An error happened. :(</div>
             <div id="error-message-div" style="font-size: 16px;"></div>
             <br/>
             Please report it:

--- a/src/circuit/CircuitDefinition.js
+++ b/src/circuit/CircuitDefinition.js
@@ -226,7 +226,6 @@ class CircuitDefinition {
                 continue;
             }
 
-            console.log(pushedGateIndexes);
             let isControl = g => g === Gates.Special.Control || g === Gates.Special.AntiControl;
             let keptGates = seq(this.columns[col].gates).
                 mapWithIndex((g, row) => pushedGateIndexes.has(row) ? null : g).

--- a/src/fallback.js
+++ b/src/fallback.js
@@ -1,7 +1,7 @@
 import describe from "src/base/Describe.js"
 
 let _alreadySeen = [];
-let showErrorDiv = (subject, body) => {
+let showErrorDiv = (callout, subject, body) => {
     let errDivStyle = document.getElementById('error-div').style;
     if (errDivStyle.opacity < 0.7) {
         // Partially faded away as user interacted with circuit.
@@ -20,6 +20,7 @@ let showErrorDiv = (subject, body) => {
     _alreadySeen.push(body);
 
     // Set shown error details.
+    document.getElementById('error-happened-div').innerText = callout;
     document.getElementById('error-message-div').innerText = subject;
     document.getElementById('error-description-div').innerText = body;
     document.getElementById('error-mailto-anchor').innerText = 'Email the issue to craig.gidney@gmail.com';
@@ -52,7 +53,7 @@ let takeScreenshotOfCanvas = () => {
  * @param {*} error The exception object.
  */
 let notifyAboutRecoveryFromUnexpectedError = (recovery, context, error) => {
-    console.warn('Recovered from unexpected error', {recovery, context, error});
+    console.error('Recovered from unexpected error', {recovery, context, error});
 
     let location = error.stack || "unknown";
     let msg = [
@@ -76,7 +77,10 @@ let notifyAboutRecoveryFromUnexpectedError = (recovery, context, error) => {
          simplifySrcUrls(location)
     ].join('\n');
 
-    showErrorDiv(recovery + ' (' + (error.message || '') + ')', msg);
+    showErrorDiv(
+        'Recovered from an error. :(',
+        recovery + ' (' + (error.message || '') + ')',
+        msg);
 };
 let simplifySrcUrls = textContainingUrls => textContainingUrls.replace(/http.+?\/src\.min\.js/g, 'src.min.js');
 
@@ -119,7 +123,7 @@ window.onerror = (errorMsg, url, lineNumber, columnNumber, errorObj) => {
             ((errorObj instanceof Object)? errorObj.stack : undefined) ||
                 (url + ":" + lineNumber + ":" + columnNumber));
 
-        showErrorDiv(errorMsg, [
+        showErrorDiv('An error happened. :(', errorMsg, [
             'URL',
             document.location,
             '',


### PR DESCRIPTION
- loadCircuitFromUrl now calls notifyAboutRecoveryFromUnexpectedError on error
- Serializer.fromJson_Gate now calls notifyAboutRecoveryFromUnexpectedError on error
- wantToPushStateIfDiffersFrom uses undefined instead of null for its empty value
- Minor tweaks to how circuit hash is set
- Error div now shows 'Recovered from Error' instead of 'An Error Happened' for errors that had a fallback