### PR TITLE
Fixed touch problems (at least on Android/Chrome)

### DIFF
--- a/src/browser/MouseWatcher.js
+++ b/src/browser/MouseWatcher.js
@@ -50,6 +50,20 @@ let addListenerUntilResultInvoked = (target, type, listener) => {
     return () => target.removeEventListener(type, listener);
 };
 
+/**
+ * @param {!EventTarget} target
+ * @param {!string} type
+ * @param {!EventListener|!Function} listener
+ * @returns {!function(void) : void}
+ */
+let addTouchListenerUntilResultInvoked = (target, type, listener) => {
+    if(target && target.preventDefault) {
+        target.preventDefault();
+    }
+    target.addEventListener(type, listener);
+    return () => target.removeEventListener(type, listener);
+};
+
 class DragWatcher {
     /**
      * @param {!HTMLElement} element
@@ -88,10 +102,10 @@ class DragWatcher {
             addListenerUntilResultInvoked(document, 'mouseleave', ev => this.handleMouseEventWith(ev, this.onLeave)),
             addListenerUntilResultInvoked(document, 'mouseenter', ev => this.handleMouseEventWith(ev, this.onEnter)),
 
-            addListenerUntilResultInvoked(e, 'touchstart', ev => this.handleTouchEventWith(ev, this.onDown)),
-            addListenerUntilResultInvoked(e, 'touchmove', ev => this.handleTouchEventWith(ev, this.onMove)),
-            addListenerUntilResultInvoked(e, 'touchend', ev => this.handleTouchEventWith(ev, this.onUp)),
-            addListenerUntilResultInvoked(e, 'touchcancel', ev => this.handleTouchEventWith(ev, this.onCancel))
+            addTouchListenerUntilResultInvoked(e, 'touchstart', ev => this.handleTouchEventWith(ev, this.onDown)),
+            addTouchListenerUntilResultInvoked(e, 'touchmove', ev => this.handleTouchEventWith(ev, this.onMove)),
+            addTouchListenerUntilResultInvoked(e, 'touchend', ev => this.handleTouchEventWith(ev, this.onUp)),
+            addTouchListenerUntilResultInvoked(e, 'touchcancel', ev => this.handleTouchEventWith(ev, this.onCancel))
         ];
 
         return () => {


### PR DESCRIPTION
@Strilanc looks like problem is solved, at least on Chrome running on Nexus 7 tablet.

All touch events requires `ev.preventDefault()` to be called. If `e.preventDefault()` is not called in `touchmove` event then browser "thinks" you are trying to scroll page and automatically fires `touchcancel`.

Cheers! :)