### PR TITLE
Add 'Clear Circuit' button

### DIFF
--- a/html/quirk.template.html
+++ b/html/quirk.template.html
@@ -24,7 +24,8 @@
                 <button id="export-button" style="min-width: 50px; min-height: 30px;">Export</button>
                 &nbsp;
                 &nbsp;
-                <button id="clear-button" style="min-width: 50px; min-height: 30px;">Clear ALL</button>
+                <button id="clear-circuit-button" style="min-width: 50px; min-height: 30px;">Clear Circuit</button>
+                <button id="clear-all-button" style="min-width: 50px; min-height: 30px;">Clear ALL</button>
                 &nbsp;
                 &nbsp;
                 <button id="undo-button" style="min-width: 50px; min-height: 30px;">Undo</button>

--- a/src/base/Revision.js
+++ b/src/base/Revision.js
@@ -61,6 +61,14 @@ class Revision {
     }
 
     /**
+     * Returns a snapshot of the current commit.
+     * @returns {*}
+     */
+    peekActiveCommit() {
+        return this._latestActiveCommit.get();
+    }
+
+    /**
      * Returns a cleared revision history, starting at the given state.
      * @param {*} state
      */

--- a/src/ui/clear.js
+++ b/src/ui/clear.js
@@ -38,11 +38,8 @@ function initClear(revision, obsIsAnyOverlayShowing) {
  * @returns {!string}
  */
 function _getEmptyCircuitState(revision) {
-    let val;
-    revision.latestActiveCommit().subscribe(jsonText => {
-        val = JSON.parse(jsonText);
-        val["cols"] = [];
-    });
+    let val = JSON.parse(revision.peekActiveCommit());
+    val["cols"] = [];
 
     return JSON.stringify(val);
 }

--- a/src/ui/clear.js
+++ b/src/ui/clear.js
@@ -19,11 +19,32 @@
 function initClear(revision, obsIsAnyOverlayShowing) {
     const EMPTY_STATE = '{"cols":[]}';
 
-    const clearButton = /** @type {!HTMLButtonElement} */ document.getElementById('clear-button');
+    const clearAllButton = /** @type {!HTMLButtonElement} */ document.getElementById('clear-all-button');
     revision.latestActiveCommit().zipLatest(obsIsAnyOverlayShowing, (r, v) => ({r, v})).subscribe(({r, v}) => {
-        clearButton.disabled = r === EMPTY_STATE || v;
+        clearAllButton.disabled = r === EMPTY_STATE || v;
     });
-    clearButton.addEventListener('click', () => revision.commit(EMPTY_STATE));
+    clearAllButton.addEventListener('click', () => revision.commit(EMPTY_STATE));
+
+    const clearCircuitButton = /** @type {!HTMLButtonElement} */ document.getElementById('clear-circuit-button');
+    revision.latestActiveCommit().zipLatest(obsIsAnyOverlayShowing, (r, v) => ({r, v})).subscribe(({r, v}) => {
+        clearCircuitButton.disabled = r === _getEmptyCircuitState(revision) || v;
+    });
+    clearCircuitButton.addEventListener('click', () => revision.commit(_getEmptyCircuitState(revision)));
+}
+
+/**
+ * Returns current state without circuit. Keeps all custom gates.
+ * @param {!Revision} revision
+ * @returns {!string}
+ */
+function _getEmptyCircuitState(revision) {
+    let val;
+    revision.latestActiveCommit().subscribe(jsonText => {
+        val = JSON.parse(jsonText);
+        val["cols"] = [];
+    });
+
+    return JSON.stringify(val);
 }
 
 export {initClear}


### PR DESCRIPTION
Added a "Clear Circuit" button that acts like "Clear ALL" but doesn't remove custom gates. Was  also considering adding a "Clear Gates" button; however, since removing a gate that is currently in the circuit raises an error, it may be better to handle deleting gates on an individual gate basis: for example, giving each custom gate a delete button (and/or a middle-click action) that raises a warning if the gate is currently placed on the circuit.

- Clear circuit (i.e: 'cols') but keep custom gates
- Add _getEmptyCircuitState to return an empty state JSON string that retains custom gates
- Rename clear-button to clear-all-button and add clear-circuit-button