### PR TITLE
Bring shaders' tails before main, fixes #378

### DIFF
--- a/src/webgl/ShaderCoders.js
+++ b/src/webgl/ShaderCoders.js
@@ -158,7 +158,7 @@ function combinedShaderPartsWithCode(shaderPartsOrDescs, tailCode) {
             }
         }
         let libCode = [...libs, ...shaderPartDescs.map(e => e.toConcretePart().code)].join('');
-        return libCode + '\n//////// tail ////////\n' + tailCode;
+        return libCode.replace('void main()', '\n//////// tail ////////\n' + tailCode + '\n//////// main ////////\nvoid main()');
     };
 
     return new WglShader(sourceMaker);


### PR DESCRIPTION
Obviously a hack but as Chrome reaches 61, Quirk will be broken without it so possibly a temporary solution.