### PR TITLE
Recognize 0 in customInitialValues

### DIFF
--- a/src/circuit/CircuitDefinition.js
+++ b/src/circuit/CircuitDefinition.js
@@ -153,7 +153,7 @@ class CircuitDefinition {
         if (newStateIndex !== undefined) {
             newVal = newStateIndex;
         }
-        if (newVal === undefined) {
+        if (newVal === undefined || newVal === 0) {
             m.delete(wire);
         } else {
             m.set(wire, newVal);

--- a/test/circuit/CircuitDefinition.test.js
+++ b/test/circuit/CircuitDefinition.test.js
@@ -1310,6 +1310,21 @@ suite.test("gateAtLocIsDisabledReason_multiwireOperations", () => {
 
 });
 
+suite.test("withSwitchedInitialStateOn", () => {
+    let c = circuit(`-
+                     -`);
+    assertThat(c.customInitialValues).isEqualTo(new Map());
+
+    c = c.withSwitchedInitialStateOn(0);
+    assertThat(c.customInitialValues).isEqualTo(new Map([[0, '1']]));
+
+    c = c.withSwitchedInitialStateOn(0);
+    assertThat(c.customInitialValues).isEqualTo(new Map([[0, '+']]));
+
+    c = c.withSwitchedInitialStateOn(0, 0);
+    assertThat(c.customInitialValues).isEqualTo(new Map());
+});
+
 suite.test("colCustomContextFromGates", () => {
     let c = circuit(`-A-B-
                      -A-A-


### PR DESCRIPTION
fixes https://github.com/Strilanc/Quirk/issues/447

I noticed this was introduced at this commit: https://github.com/Strilanc/Quirk/commit/8e28c2a5b014615771afb9ab23630cffe0b0556b

The [INITIAL_STATES_TO_GATES](https://github.com/Strilanc/Quirk/blame/master/src/gates/AllGates.js#L357) list uses `undefined` instead of 0 to represent |0>, so passing in `0` to the function will not delete it from the `init: []` map.

I tested locally and this seems to fix it!
