### PR TITLE
Removed the `touch-action: none` claim about Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Quirk assumes you already know background facts like "each wire represents a qub
 **Notable limitations**:
 
 - Can't recohere measured qubits (because measurement is implemented as a hack based on the [deferred measurement principle](https://en.wikipedia.org/wiki/Deferred_Measurement_Principle)).
-- Dragging works poorly in Firefox on Android (because Firefox doesn't support [`touch-action: none`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) yet).
 
 **Try it out**:
 


### PR DESCRIPTION
Removed 

> - Dragging works poorly in Firefox on Android (because Firefox doesn't support [`touch-action: none`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) yet).

Firefox, currently v82, gained `touch-action: none` in v52, March 7, 2017

https://www.mozilla.org/en-US/firefox/52.0/releasenotes/

https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action